### PR TITLE
Cursor-controlled repulsor

### DIFF
--- a/include/engine.h
+++ b/include/engine.h
@@ -16,6 +16,7 @@ public:
     void run(std::function<void()> mainLoopCallback = [](){}) { engine_.run(mainLoopCallback); }
     void updateAttractor(vec2 newPosition) { engine_.updateAttractor(newPosition); }
     void updateRepulsor( vec2 newPosition) { engine_.updateRepulsor( newPosition); }
+    void setRepulsorFollowsCursor(bool enabled) { engine_.setRepulsorFollowsCursor(enabled); }
 
 private:
     engine_impl::Engine engine_;

--- a/test-boids.cpp
+++ b/test-boids.cpp
@@ -10,6 +10,7 @@ int main() {
     float theta = 0.0;
 
     engine::Engine eng(N_BOIDS);
+    eng.setRepulsorFollowsCursor(true);
     eng.run([&]() {
         theta += 0.01;
         if (theta > 2*M_PI) theta -= 2*M_PI;


### PR DESCRIPTION
Optional switch to control the repulsor position via cursor, to make boids testing without the tracker easier.